### PR TITLE
ci: add deployment configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,13 +34,75 @@ jobs:
           name: Run build
           command: npm run build
 
+  deploy_integration:
+    docker:
+      - image: circleci/python:3.7
+    working_directory: ~/spokestack
+    steps:
+      - checkout
+      - setup_remote_docker
+
+      # attach build already done
+      - attach_workspace:
+          at: ~/spokestack
+
+      # update the service
+      - run:
+          name: Push the node server and update the ecs service
+          command: |
+            python3 -m venv ~/venv
+            source ~/venv/bin/activate
+            pip install awscli
+            cd examples/with-next
+            aws configure set region us-east-1
+            deploy/update.sh integration
+
+  deploy_production:
+    docker:
+      - image: circleci/python:3.7
+    working_directory: ~/spokestack
+    steps:
+      - checkout
+      - setup_remote_docker
+
+      # attach build already done
+      - attach_workspace:
+          at: ~/spokestack
+
+      # update the service
+      - run:
+          name: Push the node server and update the ecs service
+          command: |
+            python3 -m venv ~/venv
+            source ~/venv/bin/activate
+            pip install awscli
+            cd examples/with-next
+            aws configure set region us-east-1
+            deploy/update.sh production
+
+
 workflows:
   version: 2
 
-  test:
+  test_and_deploy:
     jobs:
       - build:
           filters:
             tags:
               only:
                 - /\d+\.\d+\.\d+/
+      - deploy_integration:
+          filters:
+            branches:
+              only: develop
+          requires:
+            - build
+      - deploy_production:
+          filters:
+            branches:
+              only: production
+            tags:
+              only:
+                - /\d+\.\d+\.\d+/
+          requires:
+            - build

--- a/examples/with-next/Dockerfile
+++ b/examples/with-next/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:12.16.3
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/
+COPY package-lock.json /usr/src/app/
+RUN npm install
+COPY . /usr/src/app
+
+RUN npm run build
+RUN npm install --production --no-save
+
+EXPOSE 80
+ENV PORT=80
+ENV GOOGLE_APPLICATION_CREDENTIALS=google-credentials.json
+
+CMD echo $GOOGLE_SPEECH_API_KEY > $GOOGLE_APPLICATION_CREDENTIALS ; exec npm start

--- a/examples/with-next/deploy/bounce.sh
+++ b/examples/with-next/deploy/bounce.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#----------------------------------------------------------------------------
+# service rolling restart script
+# . tell ecs to force a new deployment, which causes it to perform a rolling
+#   restart of the tasks/containers associated with the service
+# . restarts are rolling, so that at most one instance is out of service,
+#   and no client requests will fail as long as there is sufficient capacity
+#   for the current load
+# . if anything goes wrong, at most one instance will remain out of service
+#   until an operator fixes the problem
+#----------------------------------------------------------------------------
+
+set -e
+
+environment=$1
+if [ -z "$environment" ]; then
+    echo "usage: bounce.sh <environment>"
+    exit 1
+fi
+
+CLUSTER=$environment-spoke-demo-node
+SERVICE=$environment-spoke-demo-node
+
+aws ecs update-service --cluster $CLUSTER --service $SERVICE --force-new-deployment

--- a/examples/with-next/deploy/update.sh
+++ b/examples/with-next/deploy/update.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#----------------------------------------------------------------------------
+# service upgrade script
+# . build the docker image
+# . push the image up to the aws ecr with the environment tag
+# . bounce the service
+#----------------------------------------------------------------------------
+
+set -e
+
+environment=$1
+if [ -z "$environment" ]; then
+    echo "usage: update.sh <environment>"
+    exit 1
+fi
+
+ECR_TAG=507792887860.dkr.ecr.us-east-1.amazonaws.com/demo.spokestack.io:$environment
+
+echo "updating $ECR_TAG"
+docker build -t $ECR_TAG .
+eval "$(aws ecr get-login | sed -e 's/-e none//g')"
+docker push $ECR_TAG
+
+exec $(dirname $0)/bounce.sh $environment


### PR DESCRIPTION
These changes add scripts for updating/restarting the fargate tasks for the example node server, as well as the circleci configuration for deploying to beta-demo.spokestack.io and demo.spokestack.io.