### PR TITLE
Use FFT width to determine which filter model to use

### DIFF
--- a/src/worker/processors/keyword.ts
+++ b/src/worker/processors/keyword.ts
@@ -178,7 +178,8 @@ export default class KeywordRecognizer implements SpeechProcessor {
     const filtered = this.frameWindow.toArray()
     const stacked = tf.stack(filtered)
     const input = [tf.expandDims(stacked), this.encodeState]
-    const result = (await this.models.encode.executeAsync(input)) as tf.Tensor[]
+    const outputNodes = ['Identity_1', 'Identity']
+    const result = (await this.models.encode.executeAsync(input, outputNodes)) as tf.Tensor[]
     this.encodeWindow.rewind().seek(1)
     this.encodeWindow.write(tf.squeeze(result[0]))
     this.encodeState = tf.squeeze(result[1], [0])
@@ -188,8 +189,7 @@ export default class KeywordRecognizer implements SpeechProcessor {
     const encoded = this.encodeWindow.toArray()
     const stacked = tf.stack(encoded)
     const input = tf.expandDims(stacked)
-    const result = this.models.detect.execute(input)
-    const detected = Array.isArray(result) ? result[0] : result
+    const detected = this.models.detect.execute(input, 'Identity') as tf.Tensor
     // look up class
     const clazz = tf.argMax(detected, 1).dataSync()[0]
     const keyword = this.config.keywordClasses[clazz]

--- a/src/worker/processors/keyword.ts
+++ b/src/worker/processors/keyword.ts
@@ -178,11 +178,11 @@ export default class KeywordRecognizer implements SpeechProcessor {
     const filtered = this.frameWindow.toArray()
     const stacked = tf.stack(filtered)
     const input = [tf.expandDims(stacked), this.encodeState]
-    const outputNodes = ['Identity_1', 'Identity']
+    const outputNodes = ['Identity', 'Identity_1']
     const result = (await this.models.encode.executeAsync(input, outputNodes)) as tf.Tensor[]
     this.encodeWindow.rewind().seek(1)
     this.encodeWindow.write(tf.squeeze(result[0]))
-    this.encodeState = tf.squeeze(result[1], [0])
+    this.encodeState = result[1]
   }
 
   async classify(context: SpeechContext) {

--- a/src/worker/processors/keyword.ts
+++ b/src/worker/processors/keyword.ts
@@ -96,7 +96,7 @@ export default class KeywordRecognizer implements SpeechProcessor {
     if (isNaN(config.sampleRate)) {
       throw new Error('sampleRate is required')
     }
-    const models = await KeywordRecognizer.loadModels(config.baseKeywordUrl, config.sampleRate)
+    const models = await KeywordRecognizer.loadModels(config.baseKeywordUrl, config.fftWidth)
     return new KeywordRecognizer(models, config as KeywordRecognizerConfig)
   }
 
@@ -133,9 +133,9 @@ export default class KeywordRecognizer implements SpeechProcessor {
     }
   }
 
-  static async loadModels(baseUrl: string, sampleRate: number): Promise<CommandModels> {
+  static async loadModels(baseUrl: string, fftWidth: number): Promise<CommandModels> {
     return Promise.all([
-      tf.loadGraphModel(`${baseUrl}/filter_${sampleRate}/model.json`),
+      tf.loadGraphModel(`${baseUrl}/filter_${fftWidth}/model.json`),
       tf.loadGraphModel(`${baseUrl}/encode/model.json`),
       tf.loadGraphModel(`${baseUrl}/detect/model.json`)
     ]).then((models) => {

--- a/src/worker/processors/wakeword.ts
+++ b/src/worker/processors/wakeword.ts
@@ -174,7 +174,6 @@ export default class WakewordTrigger implements SpeechProcessor {
     const input = [tf.expandDims(stacked), this.encodeState]
     const outputNodes = ['Identity', 'Identity_1']
     const result = (await this.models.encode.executeAsync(input, outputNodes)) as tf.Tensor[]
-    // console.log(JSON.stringify(result))
     this.encodeWindow.rewind().seek(1)
     this.encodeWindow.write(tf.squeeze(result[0]))
     this.encodeState = result[1]

--- a/src/worker/processors/wakeword.ts
+++ b/src/worker/processors/wakeword.ts
@@ -172,7 +172,8 @@ export default class WakewordTrigger implements SpeechProcessor {
     const filtered = this.frameWindow.toArray()
     const stacked = tf.stack(filtered)
     const input = [tf.expandDims(stacked), this.encodeState]
-    const result = (await this.models.encode.executeAsync(input)) as tf.Tensor[]
+    const outputNodes = ['Identity', 'Identity_1']
+    const result = (await this.models.encode.executeAsync(input, outputNodes)) as tf.Tensor[]
     // console.log(JSON.stringify(result))
     this.encodeWindow.rewind().seek(1)
     this.encodeWindow.write(tf.squeeze(result[0]))
@@ -184,8 +185,7 @@ export default class WakewordTrigger implements SpeechProcessor {
     const encoded = this.encodeWindow.toArray()
     const stacked = tf.stack(encoded)
     const input = tf.expandDims(stacked)
-    const result = this.models.detect.execute(input)
-    const detected = Array.isArray(result) ? result[0] : result
+    const detected = this.models.detect.execute(input, 'Identity') as tf.Tensor
     const confidence = tf.max(detected).dataSync()[0]
 
     // console.log(`wakeword: ${confidence.toFixed(6)}`)

--- a/src/worker/processors/wakeword.ts
+++ b/src/worker/processors/wakeword.ts
@@ -84,7 +84,7 @@ export default class WakewordTrigger implements SpeechProcessor {
     if (!config.baseWakewordUrl) {
       throw new Error('wakeword URL required')
     }
-    const models = await WakewordTrigger.loadModels(config.baseWakewordUrl)
+    const models = await WakewordTrigger.loadModels(config.baseWakewordUrl, config.sampleRate)
     return new WakewordTrigger(models, config as WakewordTriggerConfig)
   }
 
@@ -125,9 +125,9 @@ export default class WakewordTrigger implements SpeechProcessor {
     }
   }
 
-  static async loadModels(baseUrl: string): Promise<CommandModels> {
+  static async loadModels(baseUrl: string, sampleRate: number): Promise<CommandModels> {
     return Promise.all([
-      tf.loadGraphModel(`${baseUrl}/filter/model.json`),
+      tf.loadGraphModel(`${baseUrl}/filter_${sampleRate}/model.json`),
       tf.loadGraphModel(`${baseUrl}/encode/model.json`),
       tf.loadGraphModel(`${baseUrl}/detect/model.json`)
     ]).then((models) => {

--- a/src/worker/processors/wakeword.ts
+++ b/src/worker/processors/wakeword.ts
@@ -84,7 +84,7 @@ export default class WakewordTrigger implements SpeechProcessor {
     if (!config.baseWakewordUrl) {
       throw new Error('wakeword URL required')
     }
-    const models = await WakewordTrigger.loadModels(config.baseWakewordUrl, config.sampleRate)
+    const models = await WakewordTrigger.loadModels(config.baseWakewordUrl, config.fftWidth)
     return new WakewordTrigger(models, config as WakewordTriggerConfig)
   }
 
@@ -125,9 +125,9 @@ export default class WakewordTrigger implements SpeechProcessor {
     }
   }
 
-  static async loadModels(baseUrl: string, sampleRate: number): Promise<CommandModels> {
+  static async loadModels(baseUrl: string, fftWidth: number): Promise<CommandModels> {
     return Promise.all([
-      tf.loadGraphModel(`${baseUrl}/filter_${sampleRate}/model.json`),
+      tf.loadGraphModel(`${baseUrl}/filter_${fftWidth}/model.json`),
       tf.loadGraphModel(`${baseUrl}/encode/model.json`),
       tf.loadGraphModel(`${baseUrl}/detect/model.json`)
     ]).then((models) => {


### PR DESCRIPTION
### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not _master_.
- [x] I have run `npm test` against my changes and tests pass.
- [x] I have added or edited necessary types and generated documentation (`npm run docs`), or no docs changes are needed.

### Description

<!--Please describe your pull request. Thank you!-->

**Fixes**:

First I realized a change didn't make it over from the keyword component to wakeword, then I realized it was the wrong change altogether. It worked on the demo wakeword because the older model named `filter` is actually present for that one, but it shouldn't work for any newly produced wakeword models.

The existing shared models (wakeword, digits, and commands) have been re-exported, and I've tested the ones in the demo project. Personal models will need to be retrained.