### PR TITLE
feat: include audio constraints

### DIFF
--- a/src/client/mic.ts
+++ b/src/client/mic.ts
@@ -13,8 +13,14 @@ declare global {
 let stream: MediaStream | undefined
 
 export function startRecord(): Promise<MediaStream | void> {
+  const constraints = {
+    autoGainControl: true,
+    channelCount: 1,
+    echoCancellation: true,
+    noiseSuppression: true
+  }
   return navigator.mediaDevices
-    .getUserMedia({ audio: true })
+    .getUserMedia({ audio: constraints })
     .then((s) => (stream = s))
     .catch(console.error.bind(console))
 }


### PR DESCRIPTION

### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not _develop_.
- [x] I have run `npm test` against my changes and tests pass.
- [x] I have added or edited necessary types and generated documentation (`npm run docs`), or no docs changes are needed.

### Description

These audio constraints (where supported) represent separate
processing stages in the other Spokestack libraries, but they
exist in the WebAudio API, so we might as well use them if we
can. A future change could pass a SpeechConfig into `startRecord`
to enable/disable individual settings if they prove to be
detrimental to a given use case.


**Fixes**: #

<!--List the issue this PR is fixing. If one does not exist, please [create one](https://github.com/spokestack/node-spokestack/issues).-->
